### PR TITLE
[fix] 컨텐츠 수집 API 동작 중 발생한 이슈 해결

### DIFF
--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -25,6 +25,9 @@ export class AdminController {
         query.platform,
         query.updateDay,
         query.originalType,
+        query.nidAuth && query.nidSes
+          ? { nidAuth: query.nidAuth, nidSes: query.nidSes }
+          : null,
       );
 
       const genres = this.contentsService.getGenres(contents);

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Query } from '@nestjs/common';
 import { ApiNoContentResponse, ApiOperation } from '@nestjs/swagger';
+import { Platforms } from 'src/common/types/contents';
 import { setRes } from 'src/common/utils/setRes';
 import { ContentsService } from 'src/modules/contents/contents.service';
 import { ScrapeContentService } from 'src/modules/scrape-content/scrape-content.service';
@@ -31,7 +32,8 @@ export class AdminController {
       const tags = this.contentsService.getTags(contents);
       await this.contentsService.saveGenres(genres);
       await this.contentsService.saveAuthors(authors);
-      await this.contentsService.saveTags(tags);
+      if (contents[0].platform !== Platforms.naver)
+        await this.contentsService.saveTags(tags);
       await this.contentsService.saveContents(contents);
       return setRes(204);
     } catch (err) {

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,16 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ContentsService } from 'src/modules/contents/contents.service';
-import { Author } from 'src/modules/contents/entities/Author';
-import { Content } from 'src/modules/contents/entities/Content';
-import { ContentAuthor } from 'src/modules/contents/entities/ContentAuthor';
-import { ContentGenre } from 'src/modules/contents/entities/ContentGenre';
-import { ContentUpdateDay } from 'src/modules/contents/entities/ContentUpdateDay';
-import { Genre } from 'src/modules/contents/entities/Genre';
-import { Platform } from 'src/modules/contents/entities/Platform';
-import { UpdateDay } from 'src/modules/contents/entities/UpdateDay';
-import { ScrapeContentService } from 'src/modules/scrape-content/scrape-content.service';
-import { Episode } from '../contents/entities/Episode';
+import { ContentsModule } from '../contents/contents.module';
 import { AuthorRepository } from '../contents/repositories/author.repository';
 import { ContentAuthorRepository } from '../contents/repositories/content-author.repository';
 import { ContentGenreRepository } from '../contents/repositories/content-genre.repository';
@@ -23,10 +12,13 @@ import { PlatformRepository } from '../contents/repositories/platform.repository
 import { TagRepository } from '../contents/repositories/tag.repository';
 import { UpdateDayRepository } from '../contents/repositories/update-day.repository';
 import { TypeOrmExModule } from '../db/typeorm-ex.module';
+import { ScrapeContentModule } from '../scrape-content/scrape-content.module';
 import { AdminController } from './admin.controller';
 
 @Module({
   imports: [
+    ScrapeContentModule,
+    ContentsModule,
     TypeOrmExModule.forCustomRepository([
       PlatformRepository,
       ContentRepository,
@@ -42,6 +34,6 @@ import { AdminController } from './admin.controller';
     ]),
   ],
   controllers: [AdminController],
-  providers: [ScrapeContentService, ContentsService],
+  providers: [],
 })
 export class AdminModule {}

--- a/src/modules/admin/dto/request.ts
+++ b/src/modules/admin/dto/request.ts
@@ -51,6 +51,20 @@ export class ScrapeContentsReqQueryDto {
   @IsEnum(UpdateDays)
   @IsNotEmpty()
   readonly updateDay: UpdateDayCode;
+
+  @ApiProperty({
+    type: String,
+    description: '(네이버 한정) NID_AUTH',
+    required: false,
+  })
+  readonly nidAuth: string;
+
+  @ApiProperty({
+    type: String,
+    description: '(네이버 한정) NID_SES',
+    required: false,
+  })
+  readonly nidSes: string;
 }
 
 export type SortOption = {

--- a/src/modules/contents/contents.service.ts
+++ b/src/modules/contents/contents.service.ts
@@ -124,6 +124,8 @@ export class ContentsService {
   }
 
   getTags(webtoons: Array<Webtoon>): Set<string> {
+    if (webtoons[0].platform === Platforms.naver) return null;
+
     const tags = new Set<string>();
     for (const webtoon of webtoons) {
       for (const tag of webtoon.tags) {
@@ -349,16 +351,18 @@ export class ContentsService {
 
     // Tag
     const tagsSelected: Array<Tag> = [];
-    for (const tagName of content.tags) {
-      const tagSelected = await this.tagRepo.findOneByName(tagName);
-      const tagSearched = tagsSelected.find(
-        (tagSelected) => tagSelected.name === tagName,
-      );
-      if (tagSelected && !tagSearched) tagsSelected.push(tagSelected);
-      else if (!tagSelected && !tagSearched) {
-        // tag 정보 저장
-        const tagSaved = await tagRepo.save(Tag.from(tagName));
-        tagsSelected.push(tagSaved);
+    if (content.tags && content.tags.length > 0) {
+      for (const tagName of content.tags) {
+        const tagSelected = await this.tagRepo.findOneByName(tagName);
+        const tagSearched = tagsSelected.find(
+          (tagSelected) => tagSelected.name === tagName,
+        );
+        if (tagSelected && !tagSearched) tagsSelected.push(tagSelected);
+        else if (!tagSelected && !tagSearched) {
+          // tag 정보 저장
+          const tagSaved = await tagRepo.save(Tag.from(tagName));
+          tagsSelected.push(tagSaved);
+        }
       }
     }
 
@@ -536,10 +540,10 @@ export class ContentsService {
       platform: content.Platform.name,
       genre: {
         main:
-          content.ContentGenres.length > 0
+          content.ContentGenres?.length > 0
             ? content.ContentGenres.find(
                 (contentGenre) => contentGenre.Genre.parentIdx === 0,
-              ).Genre.name
+              )?.Genre.name
             : '',
         sub:
           content.ContentGenres.length > 0

--- a/src/modules/contents/entities/Episode.ts
+++ b/src/modules/contents/entities/Episode.ts
@@ -63,6 +63,14 @@ export class Episode {
   @JoinColumn({ name: 'contentIdx', referencedColumnName: 'idx' })
   Content: Content;
 
+  private static convertCreateDate(createDate: string): Date {
+    const regexOfNaver = /^([0-2]\d|3[0-1])\.(0[1-9]|1[0-2])\.(\d{2})$/;
+    const regexOfKakaoWebtoon =
+      /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
+    if (regexOfNaver.test(createDate)) return new Date(`20${createDate}`);
+    else if (regexOfKakaoWebtoon.test(createDate)) return new Date(createDate);
+  }
+
   static from(contentIdx: number, episodeInfo: WebtoonEpisodeInfo): Episode {
     const episode = new Episode();
     episode.ContentIdx = contentIdx;
@@ -72,10 +80,10 @@ export class Episode {
     episode.urlOfMobile = episodeInfo.urlOfMobile;
     episode.thumbnailUrl = episodeInfo.thumbnailUrl;
     episode.isFree = episodeInfo.isFree;
-    episode.createdAt =
-      episodeInfo.createDate !== ''
-        ? new Date(`20${episodeInfo.createDate}`)
-        : new Date(Date.now());
+    // kakao: 2022-09-11T13:00:00Z
+    // naver: 21.06.27
+    console.log(episodeInfo.createDate);
+    episode.createdAt = this.convertCreateDate(episodeInfo.createDate);
     return episode;
   }
 }


### PR DESCRIPTION
- 네이버 웹툰 컨텐츠 크롤링 시 태그 정보 수집 로직 실행 중 실패 이슈 해결
- 카카오 웹툰 및 네이버 웹툰 에피소드 createDate 변환 중 실패 이슈 해결
- 로그인한 사용자만 접근 가능한 컨텐츠 페이지 접근 허용을 위해 nidAuth, nidSes 토큰 쿼리 추가 