### PR TITLE
feat: 배너 조회 API 조회 기준 수정

### DIFF
--- a/src/common/common.constant.ts
+++ b/src/common/common.constant.ts
@@ -24,3 +24,4 @@ export const kakaoWebtoonAxiosConfig = {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
   },
 };
+export const BANNER_CONTENT_COUNT = 6;

--- a/src/modules/contents/contents.service.ts
+++ b/src/modules/contents/contents.service.ts
@@ -830,9 +830,7 @@ export class ContentsService {
 
   async getBannerContents() {
     try {
-      const today = getCurrentDay() as UpdateDayCode;
-      const contents = await this.contentRepo.findTodayBannerContents(today);
-      const bannerContents = this.getEveryPlatformContentsBy(contents, 2);
+      const bannerContents = await this.contentRepo.findBannerContents();
       const items =
         bannerContents.length > 0
           ? bannerContents.map((content) => ({
@@ -859,24 +857,5 @@ export class ContentsService {
       console.error(err);
       return null;
     }
-  }
-  getEveryPlatformContentsBy(contents: Content[], limit: number): Content[] {
-    if (contents.length === 0) return [];
-
-    const filteredContents = [];
-    let naverCount = 0,
-      kakaoCount = 0;
-    for (const content of contents) {
-      if (content.Platform.name === 'kakao') {
-        if (kakaoCount === limit) continue;
-        filteredContents.push(content);
-        kakaoCount++;
-      } else if (content.Platform.name === 'naver') {
-        if (naverCount === limit) continue;
-        filteredContents.push(content);
-        naverCount++;
-      }
-    }
-    return filteredContents;
   }
 }

--- a/src/modules/contents/repositories/contents.repository.ts
+++ b/src/modules/contents/repositories/contents.repository.ts
@@ -1,11 +1,11 @@
+import { BANNER_CONTENT_COUNT } from 'src/common/common.constant';
 import {
   ContentType,
   PlatformType,
   UpdateDayCode,
 } from 'src/common/types/contents';
-import { getContentType } from 'src/common/utils/getContentType';
 import { CustomRepository } from 'src/modules/db/typeorm-ex.decorator';
-import { FindOptionsWhere, InsertResult, Like, Repository } from 'typeorm';
+import { InsertResult, Repository } from 'typeorm';
 import { FindContentsOption } from '../dto/db';
 import { SortOptions, SortOptionType } from '../dto/request';
 import { Content } from '../entities/Content';
@@ -240,17 +240,20 @@ export class ContentRepository extends Repository<Content> {
     return qb.getManyAndCount();
   }
 
-  async findTodayBannerContents(updateDay: UpdateDayCode) {
+  async findBannerContents() {
     const qb = this.createQueryBuilder('content')
       .leftJoinAndSelect('content.Platform', 'platform')
       .leftJoinAndSelect('content.ContentUpdateDays', 'contentUpdateDays')
       .leftJoinAndSelect('contentUpdateDays.UpdateDay', 'updateDay')
       .leftJoinAndSelect('content.ContentGenres', 'contentGenres')
       .leftJoinAndSelect('contentGenres.Genre', 'genre');
-
-    qb.where('updateDay.name = :name', { name: updateDay });
+    // 카카오 한정
+    qb.where('content.platformIdx = :platformIdx', { platformIdx: 2 });
+    // 신작만
     qb.andWhere('content.isNew = :isNew', { isNew: true });
-    qb.addOrderBy('content.platformIdx', 'ASC');
+    // 최신순
+    qb.addOrderBy('content.startedAt', 'DESC');
+    qb.limit(BANNER_CONTENT_COUNT);
     return qb.getMany();
   }
 }


### PR DESCRIPTION
배너 조회 API 조건 : 요일 구분 X, 조회 개수 6개, 플랫폼 : 카카오 한정, 신작만, 최신순